### PR TITLE
Bugfix: Set loader on local copy of jinja environment

### DIFF
--- a/nornir_jinja2/plugins/tasks/template_file.py
+++ b/nornir_jinja2/plugins/tasks/template_file.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Any, Optional, Dict, Callable
 
 from nornir.core.task import Result, Task
@@ -32,7 +33,7 @@ def template_file(
     jinja_filters = jinja_filters or {}
 
     if jinja_env:
-        env = jinja_env
+        env = copy.deepcopy(jinja_env)
         env.loader = FileSystemLoader(path)
     else:
         env = Environment(

--- a/nornir_jinja2/plugins/tasks/template_file.py
+++ b/nornir_jinja2/plugins/tasks/template_file.py
@@ -33,6 +33,7 @@ def template_file(
 
     if jinja_env:
         env = jinja_env
+        env.loader = FileSystemLoader(path)
     else:
         env = Environment(
             loader=FileSystemLoader(path), undefined=StrictUndefined, trim_blocks=True,

--- a/nornir_jinja2/plugins/tasks/template_string.py
+++ b/nornir_jinja2/plugins/tasks/template_string.py
@@ -31,7 +31,6 @@ def template_string(
 
     if jinja_env:
         env = jinja_env
-        env.loader = FileSystemLoader(path)
     else:
         env = Environment(undefined=StrictUndefined, trim_blocks=True,)
     env.filters.update(jinja_filters)

--- a/nornir_jinja2/plugins/tasks/template_string.py
+++ b/nornir_jinja2/plugins/tasks/template_string.py
@@ -31,6 +31,7 @@ def template_string(
 
     if jinja_env:
         env = jinja_env
+        env.loader = FileSystemLoader(path)
     else:
         env = Environment(undefined=StrictUndefined, trim_blocks=True,)
     env.filters.update(jinja_filters)


### PR DESCRIPTION
When adding the feature to specify a user defined jinja_env I think I opened up an opportunity for users to shoot themselves in the foot (I certainly did myself) by setting the env.loader in the referenced jinja_env argument instead of a local copy of the jinja_env object. If the code calling template_file uses the same jinja_env object in two threads with different FileSystemLoader paths, for example when one thread renders EOS templates from one directory and another thread renders JunOS templates from another directory, they will both update the same env.loader path causing the right templates not to be found. This could be fixed by the code calling template_file of course, but I think it's probably safer to fix with something like this patch maybe?