### PR TITLE
Add test: test_jinja_filter

### DIFF
--- a/tests/unit/test_template_string.py
+++ b/tests/unit/test_template_string.py
@@ -4,7 +4,6 @@ from jinja2 import TemplateSyntaxError
 from nornir_jinja2.plugins.tasks import template_string
 
 
-
 data_dir = "{}/test_data".format(os.path.dirname(os.path.realpath(__file__)))
 
 simple_j2 = """
@@ -31,8 +30,10 @@ host-name {{ host
 my_var: {{ my_var}}
 """
 
+
 def jinja_filter_to_upper(value):
     return str(value).upper()
+
 
 class Test(object):
     def test_template_string(self, nr):

--- a/tests/unit/test_template_string.py
+++ b/tests/unit/test_template_string.py
@@ -1,8 +1,8 @@
 import os
 
+from jinja2 import TemplateSyntaxError
 from nornir_jinja2.plugins.tasks import template_string
 
-from jinja2 import TemplateSyntaxError
 
 
 data_dir = "{}/test_data".format(os.path.dirname(os.path.realpath(__file__)))

--- a/tests/unit/test_template_string.py
+++ b/tests/unit/test_template_string.py
@@ -15,6 +15,14 @@ my_var: {{ my_var}}
 
 """
 
+simple2_j2 = """
+
+host-name: {{ host }}
+
+my_var: {{ my_var | to_upper }}
+
+"""
+
 broken_j2 = """
 #Broken template
 
@@ -23,6 +31,8 @@ host-name {{ host
 my_var: {{ my_var}}
 """
 
+def jinja_filter_to_upper(value):
+    return str(value).upper()
 
 class Test(object):
     def test_template_string(self, nr):
@@ -36,6 +46,22 @@ class Test(object):
                 assert "my_var: comes_from_host1.group_1" in r.result
             if h == "host2.group_1":
                 assert "my_var: comes_from_group_1" in r.result
+
+    def test_jinja_filter(self, nr):
+        filters = {
+            "to_upper": jinja_filter_to_upper,
+        }
+        result = nr.run(template_string, template=simple2_j2, my_var="asd", jinja_filters=filters)
+
+        assert result
+        for h, r in result.items():
+            assert "host-name: {}".format(h) in r.result
+            if h == "host1.group_1":
+                assert "my_var: COMES_FROM_HOST1.GROUP_1" in r.result
+            if h == "host2.group_1":
+                assert "my_var: COMES_FROM_GROUP_1" in r.result
+            if h == "dev3.group_2":
+                assert "my_var: ASD" in r.result
 
     def test_template_string_error_broken_string(self, nr):
         results = nr.run(template_string, template=broken_j2)

--- a/tests/unit/test_template_string.py
+++ b/tests/unit/test_template_string.py
@@ -52,7 +52,9 @@ class Test(object):
         filters = {
             "to_upper": jinja_filter_to_upper,
         }
-        result = nr.run(template_string, template=simple2_j2, my_var="asd", jinja_filters=filters)
+        result = nr.run(
+            template_string, template=simple2_j2, my_var="asd", jinja_filters=filters
+        )
 
         assert result
         for h, r in result.items():


### PR DESCRIPTION
Added Test for jinja_filter functionality

```bash
$ poetry run pytest -v
================================================= test session starts ==================================================
platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1 -- /home/jifox/.cache/pypoetry/virtualenvs/nornir-jinja2-kGdgiMPH-py3.8/bin/python
cachedir: .pytest_cache
rootdir: /home/jifox/nornir/nornir_jinja2, configfile: setup.cfg
plugins: pylama-7.7.1, nbval-0.9.6
collected 5 items                                                                                                      

tests/unit/test_template_file.py::Test::test_template_file PASSED                                                [ 20%]
tests/unit/test_template_file.py::Test::test_template_file_error_broken_file PASSED                              [ 40%]
tests/unit/test_template_string.py::Test::test_template_string PASSED                                            [ 60%]
tests/unit/test_template_string.py::Test::test_jinja_filter PASSED                                               [ 80%]
tests/unit/test_template_string.py::Test::test_template_string_error_broken_string PASSED                        [100%]

=================================================== warnings summary ===================================================
../../.cache/pypoetry/virtualenvs/nornir-jinja2-kGdgiMPH-py3.8/lib/python3.8/site-packages/_pytest/config/__init__.py:1233
  /home/jifox/.cache/pypoetry/virtualenvs/nornir-jinja2-kGdgiMPH-py3.8/lib/python3.8/site-packages/_pytest/config/__init__.py:1233: PytestConfigWarning: Unknown config option: python_paths
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

-- Docs: https://docs.pytest.org/en/stable/warnings.html
============================================= 5 passed, 1 warning in 0.31s =============================================
```