### PR TITLE
Mark path as optional and do not override jinja_env loader

### DIFF
--- a/nornir_jinja2/plugins/tasks/template_file.py
+++ b/nornir_jinja2/plugins/tasks/template_file.py
@@ -10,7 +10,7 @@ FiltersDict = Optional[Dict[str, Callable[..., str]]]
 def template_file(
     task: Task,
     template: str,
-    path: str,
+    path: Optional[str] = None,
     jinja_filters: Optional[FiltersDict] = None,
     jinja_env: Optional[Environment] = None,
     **kwargs: Any
@@ -33,7 +33,6 @@ def template_file(
 
     if jinja_env:
         env = jinja_env
-        env.loader = FileSystemLoader(path)
     else:
         env = Environment(
             loader=FileSystemLoader(path),

--- a/nornir_jinja2/plugins/tasks/template_file.py
+++ b/nornir_jinja2/plugins/tasks/template_file.py
@@ -33,12 +33,15 @@ def template_file(
 
     if jinja_env:
         env = jinja_env
-    else:
+    elif path:
         env = Environment(
             loader=FileSystemLoader(path),
             undefined=StrictUndefined,
             trim_blocks=True,
         )
+    else:
+        raise ValueError("Either jinja_env or path must be provided")
+
     env.filters.update(jinja_filters)
     t = env.get_template(template)
     text = t.render(host=task.host, **kwargs)

--- a/tests/unit/test_template_file.py
+++ b/tests/unit/test_template_file.py
@@ -1,9 +1,8 @@
 import os
 
+from jinja2 import Environment, TemplateSyntaxError
+
 from nornir_jinja2.plugins.tasks import template_file
-
-from jinja2 import TemplateSyntaxError
-
 
 data_dir = "{}/test_data".format(os.path.dirname(os.path.realpath(__file__)))
 
@@ -28,4 +27,28 @@ class Test(object):
         for result in results.values():
             processed = True
             assert isinstance(result.exception, TemplateSyntaxError)
+        assert processed
+
+    def test_template_file_no_path_or_jinja_env(self, nr):
+        results = nr.run(template_file, template="simple.j2", my_var="asd")
+
+        processed = False
+        for result in results.values():
+            processed = True
+            assert isinstance(result.exception, TypeError)
+        assert processed
+
+    def test_template_file_jinja_env_without_loader(self, nr):
+        jinja_env = Environment(
+            loader=None,
+            trim_blocks=True,
+        )
+        results = nr.run(
+            template_file, template="simple.j2", my_var="asd", jinja_env=jinja_env
+        )
+
+        processed = False
+        for result in results.values():
+            processed = True
+            assert isinstance(result.exception, TypeError)
         assert processed

--- a/tests/unit/test_template_file.py
+++ b/tests/unit/test_template_file.py
@@ -35,7 +35,7 @@ class Test(object):
         processed = False
         for result in results.values():
             processed = True
-            assert isinstance(result.exception, TypeError)
+            assert isinstance(result.exception, ValueError)
         assert processed
 
     def test_template_file_jinja_env_without_loader(self, nr):


### PR DESCRIPTION
Resolves issues seen in #5.
However reverts work done in: #3.

@dbarrosop do you think this approach can work?
Overriding the loader has proven to be causing issues.

I think it makes sense when the user passes in a jinja_env we should assume the loader is also set properly and therefore the path will be optional.

Main idea is to try to generate the template and any Exceptions that may rise are lifted up to the user running the task instead of having alot of assertions in this code.