### PR TITLE
Prepare 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,68 @@
+# Changelog
+
+## 1.0.0
+
+First stable release. The major bump signals the breaking change below, and leaves the
+`0.x` range where dependency resolvers treat every release as potentially breaking (#8).
+
+### Breaking changes
+
+- `template_file` no longer overrides the loader on a user-supplied `jinja_env` (#17).
+  Previously, passing `jinja_env` caused the task to set `env.loader = FileSystemLoader(path)`
+  on every run, mutating the caller's environment. This caused wrong-template and
+  template-not-found errors when a single `jinja_env` was shared across threads rendering
+  from different paths (#5).
+- `path` is now optional (`path: Optional[str] = None`) and is **ignored when `jinja_env`
+  is provided**. If you pass a `jinja_env`, you are responsible for configuring its loader.
+- Calling `template_file` with neither `path` nor `jinja_env` now raises `ValueError`.
+
+#### Who is affected
+
+Anyone calling `template_file(jinja_env=<env without a loader>, path=<dir>)` and relying on
+the task to wire up the loader from `path`. After 1.0.0 that environment must carry its own
+loader, otherwise `get_template` raises `TypeError`.
+
+#### Migration
+
+Before:
+
+```python
+task.run(template_file, template=tpl, jinja_env=my_env, path=f"templates/{platform}")
+```
+
+After — set the loader on your own environment. A per-path factory also avoids the
+shared-mutation race:
+
+```python
+def env_for(path):
+    return Environment(
+        loader=FileSystemLoader(path),
+        undefined=StrictUndefined,
+        trim_blocks=True,
+    )
+
+task.run(template_file, template=tpl, jinja_env=env_for(f"templates/{platform}"))
+```
+
+The `path`-only usage is unchanged:
+
+```python
+task.run(template_file, template=tpl, path="templates")
+```
+
+### Other changes
+
+- Python 3.10 through 3.14 are supported and tested; Python 3.8 and 3.9 are dropped (#18, #26).
+- The project builds with `uv` instead of Poetry, and all tooling configuration now lives in
+  `pyproject.toml` (#23, #25, #27).
+- Formatting and linting moved from black/pylama to ruff (#20, #25).
+- Fixed the spelling of `template_string` (#11).
+
+## 0.2.0
+
+- Bumped to jinja2 3 (#7).
+- Fixed handling of a custom jinja environment (#3).
+
+## 0.1.0
+
+Initial release.

--- a/nornir_jinja2/plugins/tasks/template_file.py
+++ b/nornir_jinja2/plugins/tasks/template_file.py
@@ -18,16 +18,23 @@ def template_file(
     """
     Renders contants of a file with jinja2. All the host data is available in the template
 
+    Either ``path`` or ``jinja_env`` must be provided.
+
     Arguments:
         template: filename
-        path: path to dir with templates
+        path: path to dir with templates. Optional, and ignored when ``jinja_env`` is given
         jinja_filters: jinja filters to enable. Defaults to nornir.config.jinja2.filters
-        jinja_env: A fully configured jinja2 environment
+        jinja_env: A fully configured jinja2 environment, including its own loader. The
+            loader is never overridden from ``path``, so the environment must be able to
+            find ``template`` on its own
         **kwargs: additional data to pass to the template
 
     Returns:
         Result object with the following attributes set:
           * result (``string``): rendered string
+
+    Raises:
+        ValueError: if neither ``path`` nor ``jinja_env`` is provided
     """
     jinja_filters = jinja_filters or {}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nornir_jinja2"
-version = "0.2.0"
+version = "1.0.0"
 description = "Jinja2 plugins for nornir"
 authors = [{ name = "David Barroso", email = "dbarrosop@dravetech.com" }]
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1509,7 +1509,7 @@ wheels = [
 
 [[package]]
 name = "nornir-jinja2"
-version = "0.2.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Prepares the `1.0.0` release requested in #24. Users get an explicit, documented
statement of the breaking change to `template_file` and how to migrate, plus a
version number that dependency resolvers no longer treat as unstable — `^0.x`
resolution has been surprising new users since #8.

## Key Changes

- Version bumped `0.2.0` -> `1.0.0`.
- New `CHANGELOG.md` covering 1.0.0, with the breaking change, who it affects, and
  before/after migration snippets, plus brief entries for 0.2.0 and 0.1.0.
- `template_file`'s docstring now states that `path` is optional, that it is ignored
  when `jinja_env` is given, that the caller must bring their own loader, and that
  `ValueError` is raised when neither is supplied.

## Related Context

- Closes #24 (release checklist).
- Documents #17, the behaviour change already merged, which fixes #5.
- Version rationale from #8.

The changelog credits #27 under tooling consolidation on the assumption it merges
first; no files it touches are modified here, so the two do not conflict.

## Test Plan

`make tests` — ruff format, ruff check, mypy, and all 7 pytest tests pass locally.
No behaviour changed, only version metadata and documentation.

Remaining release steps are manual and out of scope for this PR: tag and publish
`1.0.0`, then close #8 and #24.