### PR TITLE
Modernize type annotations to PEP 585/604 syntax

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,4 @@
 import sys
-from typing import List
 
 sys.path.insert(0, "../")
 
@@ -41,7 +40,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns: List[str] = []
+exclude_patterns: list[str] = []
 
 
 # -- Options for HTML output -------------------------------------------------

--- a/nornir_jinja2/plugins/tasks/template_file.py
+++ b/nornir_jinja2/plugins/tasks/template_file.py
@@ -1,18 +1,19 @@
-from typing import Any, Optional, Dict, Callable
+from collections.abc import Callable
+from typing import Any
 
 from nornir.core.task import Result, Task
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
-FiltersDict = Optional[Dict[str, Callable[..., str]]]
+FiltersDict = dict[str, Callable[..., str]]
 
 
 def template_file(
     task: Task,
     template: str,
-    path: Optional[str] = None,
-    jinja_filters: Optional[FiltersDict] = None,
-    jinja_env: Optional[Environment] = None,
+    path: str | None = None,
+    jinja_filters: FiltersDict | None = None,
+    jinja_env: Environment | None = None,
     **kwargs: Any,
 ) -> Result:
     """

--- a/nornir_jinja2/plugins/tasks/template_string.py
+++ b/nornir_jinja2/plugins/tasks/template_string.py
@@ -1,18 +1,19 @@
-from typing import Any, Optional, Dict, Callable
+from collections.abc import Callable
+from typing import Any
 
 from nornir.core.task import Result, Task
 
 from jinja2 import Environment, StrictUndefined
 
 
-FiltersDict = Optional[Dict[str, Callable[..., str]]]
+FiltersDict = dict[str, Callable[..., str]]
 
 
 def template_string(
     task: Task,
     template: str,
-    jinja_filters: Optional[FiltersDict] = None,
-    jinja_env: Optional[Environment] = None,
+    jinja_filters: FiltersDict | None = None,
+    jinja_env: Environment | None = None,
     **kwargs: Any,
 ) -> Result:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,8 @@ line-ending = "auto"
 
 [tool.ruff.lint]
 # Port of the previous pylama linters: pep8 (E/W) + pyflakes (F) + mccabe (C90)
-select = ["E", "W", "F", "C90"]
+# UP keeps annotations on PEP 585/604 syntax now that we require Python >= 3.10
+select = ["E", "W", "F", "C90", "UP"]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,9 +18,9 @@ def nr(request):
         inventory={
             "plugin": "SimpleInventory",
             "options": {
-                "host_file": "{}/inventory_data/hosts.yaml".format(dir_path),
-                "group_file": "{}/inventory_data/groups.yaml".format(dir_path),
-                "defaults_file": "{}/inventory_data/defaults.yaml".format(dir_path),
+                "host_file": f"{dir_path}/inventory_data/hosts.yaml",
+                "group_file": f"{dir_path}/inventory_data/groups.yaml",
+                "defaults_file": f"{dir_path}/inventory_data/defaults.yaml",
             },
         },
         dry_run=True,

--- a/tests/unit/test_template_file.py
+++ b/tests/unit/test_template_file.py
@@ -4,10 +4,10 @@ from jinja2 import Environment, TemplateSyntaxError
 
 from nornir_jinja2.plugins.tasks import template_file
 
-data_dir = "{}/test_data".format(os.path.dirname(os.path.realpath(__file__)))
+data_dir = f"{os.path.dirname(os.path.realpath(__file__))}/test_data"
 
 
-class Test(object):
+class Test:
     def test_template_file(self, nr):
         result = nr.run(template_file, template="simple.j2", my_var="asd", path=data_dir)
 

--- a/tests/unit/test_template_string.py
+++ b/tests/unit/test_template_string.py
@@ -4,7 +4,7 @@ from jinja2 import TemplateSyntaxError
 from nornir_jinja2.plugins.tasks import template_string
 
 
-data_dir = "{}/test_data".format(os.path.dirname(os.path.realpath(__file__)))
+data_dir = f"{os.path.dirname(os.path.realpath(__file__))}/test_data"
 
 simple_j2 = """
 
@@ -35,14 +35,14 @@ def jinja_filter_to_upper(value):
     return str(value).upper()
 
 
-class Test(object):
+class Test:
     def test_template_string(self, nr):
 
         result = nr.run(template_string, template=simple_j2, my_var="asd")
 
         assert result
         for h, r in result.items():
-            assert "host-name: {}".format(h) in r.result
+            assert f"host-name: {h}" in r.result
             if h == "host1.group_1":
                 assert "my_var: comes_from_host1.group_1" in r.result
             if h == "host2.group_1":
@@ -56,7 +56,7 @@ class Test(object):
 
         assert result
         for h, r in result.items():
-            assert "host-name: {}".format(h) in r.result
+            assert f"host-name: {h}" in r.result
             if h == "host1.group_1":
                 assert "my_var: COMES_FROM_HOST1.GROUP_1" in r.result
             if h == "host2.group_1":


### PR DESCRIPTION
## Summary

The public task signatures — the part users actually read, since they surface in
the Sphinx API docs and in editor tooltips — were still written against the
legacy `typing` aliases even though the project requires Python >= 3.10. This
moves them to the built-in generics and `X | None` syntax, so what a user sees
when they hover `template_file` matches the Python they're writing.

## Key Changes

- `template_file` and `template_string` now advertise `str | None`,
  `Environment | None`, and `FiltersDict | None` instead of `Optional[...]`.
- `FiltersDict` is a plain `dict[str, Callable[..., str]]`. It previously
  resolved to `Optional[Dict[...]]` and was then used as
  `Optional[FiltersDict]`, so the optionality was declared twice; the parameters
  now carry it exactly once.
- Ruff's `UP` rules are enabled, so the old syntax cannot creep back in.
- Turning on `UP` also flagged pre-existing `.format()` calls and redundant
  `(object)` bases in the tests and docs config; those are auto-fixed here to
  keep the lint suite clean.

## Related Context

Closes #29.

`FiltersDict` is not in `nornir_jinja2.plugins.tasks.__all__`, so narrowing it
is not part of the documented API surface.

## Test Plan

```bash
uv run ruff check .
uv run ruff format --check .
uv run mypy nornir_jinja2
uv run pytest
```

All four pass locally (7 tests). The change is annotations only — no runtime
behaviour is touched, and `mypy` still runs with `python_version = "3.10"`.
